### PR TITLE
Add CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  pull_request_target:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  analyze-forks:
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout PR head commit safely (no token)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          fetch-depth: 2
+
+      - name: Initialize CodeQL (auto languages, no build)
+        uses: github/codeql-action/init@v3
+        with:
+          languages: auto
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+


### PR DESCRIPTION
Adds CodeQL workflow with safe fork PR handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions CodeQL workflow with a language matrix and a fork-safe path for pull_request_target events.
> 
> - **CI/CD**:
>   - **CodeQL Workflow** added at `.github/workflows/codeql.yml`:
>     - Triggers: `push`, `pull_request`, `pull_request_target`, `workflow_dispatch`.
>     - Jobs:
>       - `analyze`: matrix over `cpp`, `csharp`, `go`, `java`, `javascript`, `python`, `ruby`; initializes, autobuilds, and analyzes.
>       - `analyze-forks`: runs on forked `pull_request_target`; safe checkout of PR head, auto-detected languages, no build.
>     - Permissions: `contents: read`, `security-events: write`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6cd2a2a2437747a28edf2bd07f96191e1a30224. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->